### PR TITLE
Updated the way map function pass arguments to the function it calls

### DIFF
--- a/src/calsen.c
+++ b/src/calsen.c
@@ -82,11 +82,8 @@ static void *_index_one_file(Node *node, va_list args) {
 }
 
 static void *_index_one_dir(Node *node, va_list args) {
-    va_list args_copy;
-    va_copy(args_copy, args);
-
-    HashTable *parsers = va_arg(args_copy, HashTable *);
-    HashTable *tf_table = va_arg(args_copy, HashTable *);
+    HashTable *parsers = va_arg(args, HashTable *);
+    HashTable *tf_table = va_arg(args, HashTable *);
 
     // get all the file to index along with their MIME type
     LinkedList *files_to_index = ll_init();
@@ -118,11 +115,8 @@ void calsen_index_files(LinkedList *dir_list, const char *output_file) {
 }
 
 static void *_idf_token_map(Node *node, va_list args) {
-    va_list args_copy;
-    va_copy(args_copy, args);
-
-    HashTable *index_table = va_arg(args_copy, HashTable *);
-    LinkedList *token_idf_list = va_arg(args_copy, HashTable *);
+    HashTable *index_table = va_arg(args, HashTable *);
+    LinkedList *token_idf_list = va_arg(args, HashTable *);
 
     double idf_val = calculate_idf(index_table, (String *)node->data);
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -210,11 +210,9 @@ static inline void _dump_line(FILE *fp, char *line, size_t size) {
 static void _dump_index_d_as_val(HTEntry *entry, va_list args) {
     // takes care of writing the individual tokens to the indexer file
     if (entry == NULL) return;
-    va_list args_copy;
-    va_copy(args_copy, args);
 
-    FILE *fp = va_arg(args_copy, FILE *);
-    String *line = va_arg(args_copy, String *);
+    FILE *fp = va_arg(args, FILE *);
+    String *line = va_arg(args, String *);
 
     string_append_charp(line, entry->key);
     string_append_char(line, '=');
@@ -228,10 +226,8 @@ static void _dump_index_map_ht_as_val(HTEntry *entry, va_list args) {
 
     if (entry == NULL) return;
     // the max size fo a filepath in linux is PATH_MAX(4096) +
-    va_list args_copy;
-    va_copy(args_copy, args);
 
-    FILE *fp = va_arg(args_copy, FILE *);
+    FILE *fp = va_arg(args, FILE *);
     String *line = string_create(PATH_MAX);
 
     string_append_charp(line, ":filename=");

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -23,9 +23,7 @@ there, was, a, fox, that, could, not, jump, ., Ha, Ha, 1, :, 23
 This function is as function to map overt the token list
 */
 static void *_to_lowercase(Node *node, va_list arg_list) {
-    va_list args_copy;
-    va_copy(args_copy, arg_list);
-    (*(va_arg(args_copy, int *)))++;  // inc the total count
+    (*(va_arg(arg_list, int *)))++;  // inc the total count
     if (node == NULL) return NULL;
     String *str = (String *)(node->data);
     int i = 0;

--- a/src/tf_idf.c
+++ b/src/tf_idf.c
@@ -65,9 +65,7 @@ HashTable *token_count(LinkedList *token_list) {
 }
 
 static void _calculate_tf_value_for_entry(HTEntry *entry, va_list args) {
-    va_list args_copy;
-    va_copy(args_copy, args);
-    size_t table_size = va_arg(args_copy, size_t);
+    size_t table_size = va_arg(args, size_t);
 
     int token_count = *((int *)(entry->value));
     free(entry->value);  // free the existing int value
@@ -89,21 +87,15 @@ void tf_table_free_int(void *int_val) {
 // =========== IDF stuff ===========
 
 static void _tf_table_iter_inner(HTEntry *entry, va_list args) {
-    va_list args_copy;
-    va_copy(args_copy, args);
-
-    int *t_count = va_arg(args_copy, int *);
-    String *token = va_arg(args_copy, String *);
+    int *t_count = va_arg(args, int *);
+    String *token = va_arg(args, String *);
 
     if (strcmp(entry->key, token->str) == 0) *t_count = *t_count + 1;
 }
 
 static void _tf_table_iter(HTEntry *entry, va_list args) {
-    va_list args_copy;
-    va_copy(args_copy, args);
-
-    int *t_count = va_arg(args_copy, int *);
-    String *token = va_arg(args_copy, String *);
+    int *t_count = va_arg(args, int *);
+    String *token = va_arg(args, String *);
 
     ht_entry_map(entry->value, _tf_table_iter_inner, t_count, token);
 }

--- a/src/utils/hash_table.c
+++ b/src/utils/hash_table.c
@@ -121,10 +121,10 @@ If the next field is modified, unexpected behavior can occur
 */
 void ht_entry_map(HashTable *table, HtEntryMapFn *fn, ...) {
     va_list args;
-    va_start(args, fn);
     for (int i = 0; i < HASH_TABLE_SIZE; i++) {
         HTEntry *entry = table->entries[i];
         while (entry != NULL) {
+            va_start(args, fn);
             fn(entry, args);
             entry = entry->next;
         }

--- a/src/utils/linked_list.c
+++ b/src/utils/linked_list.c
@@ -139,8 +139,8 @@ void ll_iter_free(LLIter *iterator) {
 void ll_map(LinkedList *list, LinkedListMapFn *fn, ...) {
     Node *temp = list->head;
     va_list args;
-    va_start(args, fn);
     while (temp != NULL) {
+        va_start(args, fn);
         temp->data = fn(temp, args);
         temp = temp->next;
     }


### PR DESCRIPTION
`va_start`, resets every time the map function called the function provided, this prevents the need of the called function from copying the args every time it need to access the args

https://github.com/Adwaith-Rajesh/calsen/issues/9