### PR TITLE
Calsenconfig #20

### DIFF
--- a/nobuild.c
+++ b/nobuild.c
@@ -1,3 +1,5 @@
+// License: GPL v3 Copyright: 2023, Adwaith Rajesh <adwaithrajesh3180@gmail.com>
+
 #define NOBUILD_IMPLEMENTATION
 #include "nobuild.h"
 
@@ -48,11 +50,7 @@ void build_src_config(char *config_file_path) {
     INFO("Building src/config");
 
     const char *src_config_dir = "./src/config";
-
-    size_t s = strlen(config_file_path) + 25;
-    char config_path[s];
-
-    snprintf(config_path, s, "-DCALSENCONFIG=\"\\\"%s\\\"\"", config_file_path);
+    char *config_path = JOIN("", "-DCALSENCONFIG=\"", config_file_path, "\"");
 
     if (!IS_DIR(src_config_dir)) {
         INFO("provided src/config dir not a dir!\n");

--- a/nobuild.c
+++ b/nobuild.c
@@ -16,6 +16,7 @@
 #define BIN_DIR "./build/bin"
 
 int in_release = 0;
+int no_load_config = 0;
 
 typedef struct {
     char parser_file_name[20];
@@ -51,6 +52,7 @@ void build_src_config(char *config_file_path) {
 
     const char *src_config_dir = "./src/config";
     char *config_path = JOIN("", "-DCALSENCONFIG=\"", config_file_path, "\"");
+    char *load_config = JOIN("", "-DLOAD_CONFIG=", no_load_config ? "0" : "1");
 
     if (!IS_DIR(src_config_dir)) {
         INFO("provided src/config dir not a dir!\n");
@@ -63,7 +65,7 @@ void build_src_config(char *config_file_path) {
                 PATH("build", "out", CONCAT(NOEXT(file), ".o")),
                 "-c",
                 PATH("src", "config", file),
-                config_path);
+                config_path, load_config);
         }
     });
 }
@@ -160,6 +162,7 @@ int main(int argc, char **argv) {
     int option_index = 0;
     struct option long_options[] = {
         {"release", no_argument, &in_release, 1},
+        {"no-load-config", no_argument, &no_load_config, 1},
         {"config", required_argument, 0, 'c'},
         {0, 0, 0, 0},
     };

--- a/src/config/calsenconfig.c
+++ b/src/config/calsenconfig.c
@@ -1,0 +1,84 @@
+// License: GPL v3 Copyright: 2023, Adwaith Rajesh <adwaithrajesh3180@gmail.com>
+
+#include "calsenconfig.h"
+
+#include <errno.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "path.h"
+
+// the config file for now is pretty straight forward.
+// this first line will the parsers dir.
+// the second line will be the ignore file path
+static int _read_line(FILE *fp, char buf[PATH_MAX]) {
+    // reads a line until \n, return the number of bytes read
+    int n_bytes = 0;
+    int ch;
+    while (((ch = fgetc(fp)) != EOF && (ch != '\n')) && n_bytes < PATH_MAX) {
+        buf[n_bytes++] = ch;
+    }
+    buf[n_bytes] = '\0';
+    return n_bytes;
+}
+
+static void _print_config_error(const char *error_msg, const char *config_file_path) {
+    fprintf(stderr, error_msg, config_file_path);
+    exit(EXIT_FAILURE);
+}
+
+static void _parse_config_file(const char *filepath, config_t *c) {
+    FILE *fp = fopen(filepath, "r");
+    if (fp == NULL) {
+        fprintf(stderr, "ERROR: could not read config file %s : %s\n", filepath, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    // try to read two lines
+    int n_bytes;
+    char temp_path[PATH_MAX];
+    char resolved_path[PATH_MAX];
+
+    n_bytes = _read_line(fp, temp_path);
+    if (n_bytes == 0) _print_config_error("path to parsers dir not specified in the config file %s\n", filepath);
+    strcpy(c->parsers_dir, get_absolute_path(temp_path, resolved_path));
+
+    n_bytes = _read_line(fp, temp_path);
+    if (n_bytes == 0) _print_config_error("path to .calsenignore file not specified in the config file %s\n", filepath);
+    strcpy(c->ignore_file, get_absolute_path(temp_path, resolved_path));
+}
+
+static void _create_config_file(const char *filepath, config_t *c) {
+}
+
+/*
+if the config file passed during compilation is "", we will check for the existence
+of ~/.config/calsen/.calsenconfig. If does not exist the file will be crated with default values,
+
+if CALSENIGNORE and CALSEN_PARSER_DIR is present as environment variables the file will not be
+parsed
+
+if a filepath was passed during compilation then the file will checked and parsed, if the file
+path is invalid then the program stops instantly.
+ */
+config_t get_calsen_config() {
+    char *parsers_dir = getenv("CALSEN_PARSER_DIR");
+    char *ignore_file = getenv("CALSENIGNORE");
+    char *passed_config = CALSENCONFIG;
+
+    config_t c;
+    char resolved_path[PATH_MAX] = {0};
+    strcpy(c.config_file, get_absolute_path(passed_config, resolved_path));
+
+    if (parsers_dir != NULL && ignore_file != NULL) {
+        strcpy(c.parsers_dir, get_absolute_path(parsers_dir, resolved_path));
+        strcpy(c.ignore_file, get_absolute_path(ignore_file, resolved_path));
+        return c;
+    }
+
+    _parse_config_file(passed_config, &c);
+
+    return c;
+}

--- a/src/config/calsenconfig.h
+++ b/src/config/calsenconfig.h
@@ -13,8 +13,9 @@ typedef struct {
     char parsers_dir[PATH_MAX];
     char ignore_file[PATH_MAX];
     char config_file[PATH_MAX];
+    char index_file[PATH_MAX];
 } config_t;
 
-config_t get_calsen_config();
+config_t *get_calsen_config();
 
 #endif

--- a/src/config/calsenconfig.h
+++ b/src/config/calsenconfig.h
@@ -9,6 +9,10 @@
 #define CALSENCONFIG "./calsenconfig"
 #endif
 
+#ifndef LOAD_CONFIG
+#define LOAD_CONFIG 1
+#endif
+
 typedef struct {
     char parsers_dir[PATH_MAX];
     char ignore_file[PATH_MAX];

--- a/src/config/calsenconfig.h
+++ b/src/config/calsenconfig.h
@@ -1,0 +1,20 @@
+// License: GPL v3 Copyright: 2023, Adwaith Rajesh <adwaithrajesh3180@gmail.com>
+
+#ifndef INCLUDE_CALSENCONFIG_H
+#define INCLUDE_CALSENCONFIG_H
+
+#include <linux/limits.h>
+
+#ifndef CALSENCONFIG
+#define CALSENCONFIG "./calsenconfig"
+#endif
+
+typedef struct {
+    char parsers_dir[PATH_MAX];
+    char ignore_file[PATH_MAX];
+    char config_file[PATH_MAX];
+} config_t;
+
+config_t get_calsen_config();
+
+#endif

--- a/src/config/calsenignore.c
+++ b/src/config/calsenignore.c
@@ -45,6 +45,20 @@ LinkedList *parse_ignore_file(const char *filepath) {
 }
 
 static int _check_pattern_match(const char *pattern, const char *str) {
+    if (*pattern == '\0' && *str == '\0') return 1;
+    if (*pattern == '\0') return 0;
+    if (*str == '\0') {
+        if (*pattern != '*') return 0;
+        return _check_pattern_match(pattern + 1, str);
+    }
+    if (*pattern == '?' || *pattern == *str) return _check_pattern_match(pattern + 1, str + 1);
+    if (*pattern == '*') return _check_pattern_match(pattern + 1, str) || _check_pattern_match(pattern, str + 1);
+    return 0;
 }
 
-int check_file_name_is_ignored(LinkedList *patterns, const char *str) {}
+int check_file_name_is_ignored(LinkedList *patterns, const char *str) {
+    for (Node *node = patterns->head; node != NULL; node = node->next) {
+        if (_check_pattern_match(((String *)node->data)->str, str)) return 1;
+    }
+    return 0;
+}

--- a/src/utils/cstring.c
+++ b/src/utils/cstring.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "memfns.h"
 
@@ -79,12 +80,9 @@ void charp_slice_print(CharPSlice *slice) {
 }
 
 void string_reset(String *string) {
-    // we kind of have to remove the null byte that was prev set
-    // might hinder with other standard lib function.
-    // so fo now the best approach is to just replace it with some random character
-    string->str[string->curr_p] = '$';
-    string->curr_p = 0;
+    memset(string->str, 0, string->size);
     string->str[0] = '\0';
+    string->curr_p = 0;
 }
 
 // check if the char can be appended, otherwise create a new string

--- a/src/utils/path.c
+++ b/src/utils/path.c
@@ -22,7 +22,8 @@ int is_dir(const char *pathname) {
 char *get_absolute_path(const char *path, char *resolved_path) {
     char *r = realpath(path, resolved_path);
     if (r == NULL) {
-        perror("could not find absolute path");
+        fprintf(stderr, "could not find absolute path of %s : %s\n",
+                path, strerror(errno));
         exit(EXIT_FAILURE);
     }
     return r;


### PR DESCRIPTION
pass a config file during compilation using
`./nobuild --config path/to/.calsenconfig`
it's also optional
`./nobuild --no-load-config`

passing the index file during reindex or search is optional. the file path will be loaded from the config file. The ignore file can be passed during run time using the CLI to the reindex subcommand

config file precedence
config file < env variables < run time args (via CLI)

new ENV variables
CALSENIGNORE, CALSEN_INDEX